### PR TITLE
[Fix] Updated font_name and text_size attributes to list type in Paragraph

### DIFF
--- a/examples/pdf_example/PDFParserExample.py
+++ b/examples/pdf_example/PDFParserExample.py
@@ -18,7 +18,7 @@ for dir_path, dir_names, file_names in walk('.\\documents'):
         '''
         document = pdf_parser.get_all_elements(lines, spaces, tables, list_of_picture)
         # To write information about structural elements, use the write_CSV method, specifying the save path
-        # document.write_CSV(dir_path + '\\csv\\' + filename + '.csv')
+        document.write_CSV(dir_path + '\\csv\\' + filename + '.csv')
         '''
         To create a JSON string from data about structural elements, which will later be sent to the classifier,
         use the create_json_to_clasifier method, which takes a list of required fields as parameters

--- a/examples/pdf_example/PDFParserExample.py
+++ b/examples/pdf_example/PDFParserExample.py
@@ -24,3 +24,4 @@ for dir_path, dir_names, file_names in walk('.\\documents'):
         use the create_json_to_clasifier method, which takes a list of required fields as parameters
         '''
         json = document.create_json()
+        print("ok")

--- a/src/PDF/PDFParser.py
+++ b/src/PDF/PDFParser.py
@@ -316,16 +316,11 @@ class PDFParser(InformalParserInterface, ABC):
                 text_size.add(round(size))
             for font in line.font_names:
                 font_name.add(font)
-            if len(line.font_names) > 1 or line.no_change_font_name is False:
-                no_change_font_name = False
-            if len(line.text_sizes) > 1 or line.no_change_text_size is False:
-                no_change_text_size = False
+            no_change_font_name = False if len(font_name) > 1 or line.no_change_font_name is False else True
+            no_change_text_size = False if len(text_size) > 1 or line.no_change_text_size is False else True
+
         pdf_paragraph.font_name = list(font_name)
         pdf_paragraph.text_size = list(text_size)
-        # if len(pdf_paragraph.lines[0].text_sizes) != 0:
-        #     pdf_paragraph.text_size = pdf_paragraph.lines[0].text_sizes[0]
-        # if len(pdf_paragraph.lines[0].font_names) != 0:
-        #     pdf_paragraph.font_name = pdf_paragraph.lines[0].font_names[0]
 
         if len(pdf_paragraph.font_name) > 1:
             pdf_paragraph.full_bold = False
@@ -450,10 +445,8 @@ class PDFParser(InformalParserInterface, ABC):
 
         while i < len(lines):
             mean = 0
-            j = 0
-            while j < len(paragraph.lines) - 1:
-                mean = mean + paragraph.spaces[j]
-                j = j + 1
+            for j in range(len(paragraph.lines)):
+                mean += paragraph.spaces[j]
             # Calculating the average value of the line spacing
             if len(paragraph.lines) - 1 > 1:
                 mean = mean / (len(paragraph.lines) - 1)

--- a/src/PDF/PDFParser.py
+++ b/src/PDF/PDFParser.py
@@ -248,8 +248,8 @@ class PDFParser(InformalParserInterface, ABC):
                                      _chars=chars))
 
                     y0 = char['y0']
-                    font_names = [page.chars[0]['fontname']]
-                    text_sizes = [page.chars[0]['size']]
+                    font_names = [char['fontname']]
+                    text_sizes = [char['size']]
                     no_change_font_name = True
                     no_change_text_size = True
                     chars = [char]
@@ -309,15 +309,31 @@ class PDFParser(InformalParserInterface, ABC):
         # Highlighting string attributes
         no_change_font_name = pdf_paragraph.lines[0].no_change_font_name
         no_change_text_size = pdf_paragraph.lines[0].no_change_text_size
+        text_size = set()
+        font_name = set()
         for line in pdf_paragraph.lines:
+            for size in line.text_sizes:
+                text_size.add(round(size))
+            for font in line.font_names:
+                font_name.add(font)
             if len(line.font_names) > 1 or line.no_change_font_name is False:
                 no_change_font_name = False
             if len(line.text_sizes) > 1 or line.no_change_text_size is False:
                 no_change_text_size = False
-        if len(pdf_paragraph.lines[0].text_sizes) != 0:
-            pdf_paragraph.text_size = pdf_paragraph.lines[0].text_sizes[0]
-        if len(pdf_paragraph.lines[0].font_names) != 0:
-            pdf_paragraph.font_name = pdf_paragraph.lines[0].font_names[0]
+        pdf_paragraph.font_name = list(font_name)
+        pdf_paragraph.text_size = list(text_size)
+        # if len(pdf_paragraph.lines[0].text_sizes) != 0:
+        #     pdf_paragraph.text_size = pdf_paragraph.lines[0].text_sizes[0]
+        # if len(pdf_paragraph.lines[0].font_names) != 0:
+        #     pdf_paragraph.font_name = pdf_paragraph.lines[0].font_names[0]
+
+        if len(pdf_paragraph.font_name) > 1:
+            pdf_paragraph.full_bold = False
+            pdf_paragraph.full_italics = False
+        else:
+            for font in pdf_paragraph.font_name:
+                pdf_paragraph.full_italics = True if 'Italics' in font else  False
+                pdf_paragraph.full_bold = True if 'Bold' in font else False
         pdf_paragraph.no_change_font_name = no_change_font_name
         pdf_paragraph.no_change_text_size = no_change_text_size
         pdf_paragraph.indent = pdf_paragraph.lines[0].x0
@@ -510,9 +526,8 @@ class PDFParser(InformalParserInterface, ABC):
 
 
         paragraph = Paragraph(_text=text, _indent=round(pt_to_sm(pdf_paragraph.indent) - 3, 2),
-                              _font_name=pdf_paragraph.font_name,
-                              _text_size=round(pdf_paragraph.text_size)
-                              if isinstance(pdf_paragraph.text_size, float) else None,
+                              _font_name=pdf_paragraph.font_name, _text_size=pdf_paragraph.text_size,
+                              _bold=pdf_paragraph.full_bold, _italics=pdf_paragraph.full_italics,
                               _line_spacing=round(pt_to_sm(pdf_paragraph.line_spacing), 2),
                               _no_change_text_size=pdf_paragraph.no_change_text_size,
                               _no_change_fontname=pdf_paragraph.no_change_font_name,

--- a/src/classes/Paragraph.py
+++ b/src/classes/Paragraph.py
@@ -185,7 +185,7 @@ class Paragraph(StructuralElement):
 
         """
         first_key = text.split(' ')[0]
-        if re.match(r'^(\d+\.)$|^(\d+\))$|^(-)$|^(–)$|^(−)$', first_key):
+        if re.match(r'^(\d+\.)$|^(\d+\))$|^(-)$|^(–)$|^(−)|^(⎯)$|^([a-z]\))$', first_key):
             return 'listLevel1'
         if re.match(r'^\d+$', first_key):
             return 'TitleLevel1'

--- a/src/classes/Paragraph.py
+++ b/src/classes/Paragraph.py
@@ -66,9 +66,8 @@ class Paragraph(StructuralElement):
                 Calculates the type of the first character of a paragraph
 
     """
-    _font_name: str
-    _text_size: float
-    _text: str
+
+    _text: str = None
     _count_of_sp_sbl: int = field(init=False)
     _count_sbl: int = field(init=False)
     _lowercase: bool = field(init=False)
@@ -84,6 +83,8 @@ class Paragraph(StructuralElement):
     _no_change_fontname: bool = None
     _no_change_text_size: bool = None
     _bbox: dict[int, tuple] = None
+    _font_name: list[str] = field(default_factory=list)
+    _text_size: list[float] = field(default_factory=list)
 
     def __post_init__(self):
         self.count_of_sp_sbl = Paragraph.get_countn_of_sp_sbl(self.text)

--- a/src/pdf/pdfclasses/PdfParagraph.py
+++ b/src/pdf/pdfclasses/PdfParagraph.py
@@ -30,12 +30,14 @@ class PdfParagraph:
 
     _indent: float = None
     _line_spacing: float = None
-    _font_name: str = None
-    _text_size: float = None
+    _font_name: list = field(default_factory=list)
+    _text_size: list = field(default_factory=list)
     _no_change_font_name: bool = None
     _no_change_text_size: bool = None
     _spaces: list = field(default_factory=list)
     _lines: list[Line] = field(default_factory=list)
+    _full_italics: bool = None
+    _full_bold: bool = None
 
     @property
     def lines(self):
@@ -100,3 +102,19 @@ class PdfParagraph:
     @no_change_text_size.setter
     def no_change_text_size(self, value: bool):
         self._no_change_text_size = value
+
+    @property
+    def full_bold(self):
+        return self._full_bold
+
+    @full_bold.setter
+    def full_bold(self, value: bool):
+        self._full_bold = value
+
+    @property
+    def full_italics(self):
+        return self._full_italics
+
+    @full_italics.setter
+    def full_italics(self, value: bool):
+        self._full_italics = value


### PR DESCRIPTION
Since a paragraph can have multiple fonts and sizes, the attribute data type has been changed to a list. And accordingly the pdf parser was also fixed