### PR TITLE
Adding coverage report collection option

### DIFF
--- a/.github/workflows/app-testing.yml
+++ b/.github/workflows/app-testing.yml
@@ -22,11 +22,11 @@ jobs:
         python-version: "3.10"
     - name: Install dependencies
       run: pip install -r requirements.txt
-    - name: Install pytest
+    - name: Running pytest and collecting coverage report
       run: |
           python -m pip install --upgrade pip
           pip install pytest
           pip install pytest-cov
-          pytest --cov ./tests/docx/
+          pytest ./tests/docx/ --cov ./tests/
     - name: Run tests and upload coverage report
       uses: codecov/codecov-action@v3.1.3

--- a/.github/workflows/app-testing.yml
+++ b/.github/workflows/app-testing.yml
@@ -27,6 +27,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           pip install pytest-cov
-          pytest --cov ./tests/
+          pytest --cov ./tests/docx/
     - name: Run tests and upload coverage report
       uses: codecov/codecov-action@v3.1.3

--- a/.github/workflows/app-testing.yml
+++ b/.github/workflows/app-testing.yml
@@ -1,10 +1,10 @@
-name: Run tests
+name: App testing
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master" , "development"]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master"]
 
 permissions:
   contents: read
@@ -26,7 +26,7 @@ jobs:
       run: |
           python -m pip install --upgrade pip
           pip install pytest
-    - name: Test docx
-      run: pytest tests/docx/test*
-    - name: Codecov
+          pip install pytest-cov
+          pytest --cov ./tests/
+    - name: Run tests and upload coverage report
       uses: codecov/codecov-action@v3.1.3

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-# created by virtualenv automatically
 venv
+
 .idea
+
+.pytest_cache
+**.pyc


### PR DESCRIPTION
Перед слиянием требуется добавить документы, запрашиваемые в тестовом модуле odt и запускать pytest для всей кодовой базы в .github/app-testing.yml. Можно это сделать в ветке-наследнике.